### PR TITLE
Extend on Maven usage, update template parameters.

### DIFF
--- a/using_images/xpaas_images/fuse.adoc
+++ b/using_images/xpaas_images/fuse.adoc
@@ -1,4 +1,4 @@
-= Red Hat JBoss Fuse Integration Services 
+= Red Hat JBoss Fuse Integration Services
 {product-author}
 {product-version}
 :data-uri:
@@ -11,36 +11,36 @@
 toc::[]
 
 == Overview
-Red Hat JBoss Fuse Integration Services is a containerized xPaaS image that is designed for use with OpenShift. It allows developers to quickly deploy applications in a hybrid cloud environment. In Fuse Integration Services application runtime is dynamic. 
+Red Hat JBoss Fuse Integration Services is a containerized xPaaS image that is designed for use with OpenShift. It allows developers to quickly deploy applications in a hybrid cloud environment. In Fuse Integration Services application runtime is dynamic.
 
 [IMPORTANT]
-There are significant differences in supported configurations and functionality in the Fuse Integration Services compared to the standalone JBoss Fuse product. 
+There are significant differences in supported configurations and functionality in the Fuse Integration Services compared to the standalone JBoss Fuse product.
 
 === Differences Between the Fuse Integration Services and the JBoss Fuse Standalone release
 There are several major functionality differences:
 
-* The Karaf shell is available only at build time and can be enabled after adding ssh and shell features. You can use `*oc rsh <podId>`* and `*/deployments/karaf/bin/client`* inside the container shell to connect to the Karaf shell. 
+* The Karaf shell is available only at build time and can be enabled after adding ssh and shell features. You can use `*oc rsh <podId>`* and `*/deployments/karaf/bin/client`* inside the container shell to connect to the Karaf shell.
 +
 [NOTE]
 You can use Karaf shell only for debugging purposes as any runtime change, for example pod restart, scaling, does not persist.
-* Administration views are available through OpenShift Web Console with Hawtio plugin. 
+* Administration views are available through OpenShift Web Console with Hawtio plugin.
 * All applications are packaged as Docker images for OpenShift.
 * Kubernetes REST API is used to orchestrate the containers.
 
-== Using Fuse Integration Services 
+== Using Fuse Integration Services
 You can start using Fuse Integration Services by creating application and deploying it to OpenShift. There are two main ways to create an application in Fuse Integration Services:
 
-* Using Maven Archetypes 
-* Using Application Templates 
+* Using Maven Archetypes
+* Using Application Templates
 
 === Using Maven Archetypes
 Creates a new project based off a Maven application template created through Archetype catalog. This catalog provides examples
-of Java and Karaf projects and supports s2i and local image build workflows. 
+of Java and Karaf projects and supports s2i and local image build workflows.
 
 ==== Maven Archetypes Catalog:
-The Maven Archetype catalog has is pre-built with following examples: 
+The Maven Archetype catalog has is pre-built with following examples:
 
-|=== 
+|===
 
 | cdi-camel-http-archetype | Creates a new Camel route using CDI in a standalone Java Container calling the remote camel-servlet quickstart
 
@@ -50,7 +50,7 @@ The Maven Archetype catalog has is pre-built with following examples:
 
 | cdi-camel-jetty-archetype | Creates a new Camel route using CDI in a standalone Java Container using Jetty as HTTP server
 
-| java-simple-mainclass-archetype | Creates a new Simple standalone Java Container (main class) 
+| java-simple-mainclass-archetype | Creates a new Simple standalone Java Container (main class)
 
 | java-camel-spring-archetype | Creates a new Camel route using Spring XML in a standalone Java container
 
@@ -60,77 +60,122 @@ The Maven Archetype catalog has is pre-built with following examples:
 
 | karaf-camel-log-archetype | Creates a new Camel Log Example
 
-|=== 
+|===
 
-You can select the the example that can best serve your purpose to create an application. 
+You can select the the example that can best serve your purpose to create an application.
 
 ==== Simple Workflow to create an application from Maven Archetype Catalog
 
-. Use Maven archetype catalog to create a sample project with the required resources. For example, following command will create a sample project: 
+. Use Maven archetype catalog to create a sample project with the required resources. In order to use archetypes it is important to configure the Maven repositories which holds the archetypes and artifacts you may need:
+
+* JBoss Fuse repository: `https://repo.fusesource.com/nexus/content/groups/public/`
+* RedHat GA repository: `https://maven.repository.redhat.com/ga`
+
+You can use then the Maven archetype catalog to create a sample project with the required resources. For example, following command will create a sample project:
 +
 ----
-$ mvn archetype:generate -Darchetype-catalog=archetype-catalog.xml 
+$ mvn archetype:generate \
+  -DarchetypeCatalog=https://repo.fusesource.com/nexus/content/groups/public/archetype-catalog.xml \
+  -Dfilter=io.fabric8.archetypes:
 ----
 
-. This will create a maven project with necessary dependencies. Maven properties and plugins that are used to create Docker images are added to the `*pom.xml*`. 
+. This will create a maven project with necessary dependencies. Maven properties and plugins that are used to create Docker images are added to the `*pom.xml*`.
+
+. Environment variables. The following environment variables must be set to communicate with OpenShift and the docker daemon:
 
 +
+|===
 
-* Maven docker variables
-+
-|=== 
+| DOCKER_HOST
+| Specifies the connection to the Docker daemon of an OpenShift Node (e.g. the Master)
+| `tcp://172.28.128.4:2375`
 
-| dockerHost (docker.host) | Use this variable to specify the URL that your Docker Daemon is listening to. If this option is not set, `*DOCKER_HOST*` environment variable will be evaluated. If this is also not set, the plugin will use *`unix:///var/run/docker.sock*` as a default. 
+| KUBERNETES_MASTER
+| Specifies the URL for contacting the OpenShift API server
+| `https://172.28.128.4:8443`
 
-| apiVersion (docker.apiVersion) | Use this variable if you are using older version of docker not compatible with the current version.
+| KUBERNETES_DOMAIN
+| Domain used for creating routes. Your OpenShift API server must be mapped to all hosts of this domain.
+| `openshift.dev`
 
-| image (docker.image) | Use this variable to restrict the operation of maven plugin goals. The value can be a single image name (either its alias or full name) or it can be a comma separated list with multiple image names. 
-
-| registry (docker.registry) | Use this variable to specify globally a registry to use for pulling and pushing images.
-
-| sourceDirectory (docker.source.dir) | Use this variable to specify the default directory that contains the assembly descriptors used by the plugin. The default value is *`src/main/docker*`. This option is only relevant for the docker:build goal.
-
-| outputDirectory (docker.target.dir) | Use this variable to specify the default output directory to be used by the plugin. The default value is target/docker and is only used for the goal docker:build. 
-
-|=== 
-
-. Build and push the project to OpenShift. You can use maven goals for building and pushing docker images. 
-
-+
-|=== 
-
-| docker:build | Builds the docker image for your maven project. 
-
-| docker:push | Pushes the locally built docker image to the global or a local docker registry. 
-
-| fabric8:json | Generates kubernetes JSON file for your maven project. 
-
-| fabric8:apply | Applies the kubernetes JSON file to the current Kubernetes environment and namespace. 
-
-|=== 
+|===
 +
 
-There are few pre-configured maven profiles that you can use to build the project. These profiles are combinations of above maven goals that simplify the build process. 
+In addition you need to be logged into OpenShift with `oc login` and select the project to which to deploy (`oc project`).
+
 
 +
-|=== 
+|===
 
-| mvn -Pf8-build | Comprises of docker:build and fabric8:json. This will build dockerfile and JSON template for a project.
+| docker:build | Builds the docker image for your maven project.
 
-| mvn -Pf8-local-deploy | Comprises of docker:build, fabric8:json, and fabric8:apply. This will create docker and JSON templates and then apply them to OpenShift. 
+| docker:push | Pushes the locally built docker image to the global or a local docker registry. This step is optional when developing on a single node OpenShift cluster.
 
-| mvn -Pf8-deploy: | Comprises of docker:build, fabric8:json, docker:push, and fabric8:apply. This will create docker and JSON templates, push them to docker registry and apply to OpenShift. 
+| fabric8:json | Generates kubernetes json file for your maven project. This goal is bound to the `package` phase and doesn't need to be called explicitely when running `mvn install`
 
-|=== 
+| fabric8:apply | Applies the kubernetes json file to the current Kubernetes environment and namespace.
+
+|===
 +
-In this example, we will build it locally by running the command: 
+
+There are few pre-configured maven profiles that you can use to build the project. These profiles are combinations of above maven goals that simplify the build process.
+
++
+|===
+
+| mvn -Pf8-build | Comprises of `clean`, `install`, `docker:build`, and `fabric8:json`. This will build dockerfile and JSON template for a project.
+
+| mvn -Pf8-local-deploy | Comprises of `clean`, `install`, `docker:build`, `fabric8:json`, and `fabric8:apply`. This will create docker and JSON templates and then apply them to OpenShift.
+
+| mvn -Pf8-deploy: | Comprises of `clean`, `docker:build`, `fabric8:json`, `docker:push`, and `fabric8:apply`. This will create docker and JSON templates, push them to docker registry and apply to OpenShift.
+
+|===
++
+In this example, we will build it locally by running the command:
 +
 ----
-$ mvn -Pf8-local-deploy 
+$ mvn -Pf8-local-deploy
 ----
-. Login to OpenShift Web Console. A pod is created for the newly created application. You can view the status of this pod, deployments and services that the application is creating. 
 
-=== Using Application Templates 
+. Login to OpenShift Web Console. A pod is created for the newly created application. You can view the status of this pod, deployments and services that the application is creating.
+
+. Authenticating against a registry. For multi node OpenShift setups, the image created must be pushed to the OpenShift registry. This registry must be reachable from the outside through an route. Authentication against this registry reuses the OpenShift authentication with `oc login`. Assuming that your OpenShift registry is exposed as `registry.openshift.dev:80` the project image can be deployed to the registry with
++
+---
+$ mvn docker:push -Ddocker.registry=registry.openshift.dev:80 \
+                  -Ddocker.username=$(oc whoami) \
+                  -Ddocker.password=$(oc whoami -t)
+---
+
+In OpenShift Docker image's users are connected to OpenShift projects. In order to be able to push to the registry this project must exist. All the examples uses the property `fabric8.dockerUser` as Docker image user which has `fabric8/` as default (note the trailing slash). When this user is used unaltered an OpenShift project 'fabric8' must exist. This can be created with 'oc new-project fabric8'.
+
+. Plugin configuration. The `docker-maven-plugin` and `fabric8-maven-plugin` which are responsible for creating Docker images and OpenShift API objects can be configured flexibly. The examples from the archetypes introduces some extra properties which can be changed when running Maven:
+
++
+|===
+
+| docker.registry
+| Registry to use for `docker:push` and `-Pf8-deploy`
+
+| docker.username
+| Username for authentication against the registry
+
+| docker.password
+| Password for authentication against the registry
+
+| docker.from
+| Base image for the application Docker image
+
+| fabric8.dockerUser
+| User used in the image's name as user part. It must contain a `/` as trailing part. The default value is `fabric8/`.
+
+| docker.image
+| The final Docker image name. Default value is `${fabric8.dockerUser}${project.artifactId}:${project.version}`
+
+|===
+
+
+=== Using Application Templates
 Applications are created through OpenShift Admin Console and CLI using application templates. If you have a JSON or YAML file that defines a template, you can upload the template to the project using the CLI. This saves the template to the project for repeated use by users with appropriate access to that project. You can add the remote Git repository location to the template using template parameters. This allows you to pull the application source from remote repository and built using source-to-image (s2i) method.
 
 . JBoss Fuse Integration Services application templates generated from archetypes depend on s2i builder *`ImageStreams`*, which MUST be created ONCE. The OpenShift installer creates them automatically, but for existing OpenShift installs it can be done with the following command:
@@ -150,7 +195,7 @@ The *`ImageStreams`* may be created in a namespace other than *`openshift`* by c
 $ oc create -f quickstart-template.json -n <project>
 ----
 
-. The template is now available for selection using the web console or the CLI. 
+. The template is now available for selection using the web console or the CLI.
 
 . Login to OpenShift Web Console. In the desired project, click *`Add to Project*` to create the objects from an uploaded template.
 
@@ -161,39 +206,64 @@ $ oc create -f quickstart-template.json -n <project>
 +
 ----
 $ oc get pods
----- 
-+ 
+----
++
 For example, template parameters for a camel-spring quickstart are:
 +
++
+|===
+| Parameter | Description | Default
+
+| APP_NAME
+| Application Name
+| Artifact name of the project
+
+| GIT_REPO
+| Git repository, required
+|
+
+| GIT_REF
+| Git ref to build
+| `master`
+
+| SERVICE_NAME
+| Exposed Service name
+|
+
+| BUILDER_VERSION
+| Builder version
+| 1.0
+
+| APP_VERSION
+| Application version
+| Maven project version
+
+| MAVEN_ARGS
+| Arguments passed to mvn in the build
+| `package -DskipTests -e`
+
+| MAVEN_ARGS_APPEND
+| Extra arguments passed to mvn, e.g. for multi-module builds use `-pl groupId:module-artifactId -am`
+|
+
+| ARTIFACT_DIR
+| Maven build directory
+| `target/`
+
+| IMAGE_STREAM_NAMESPACE
+| Namespace in which the Fuse ImageStreams are installed.
+|
+
+| BUILD_SECRET
+| generated if empty. The secret needed to trigger a build.
+|
+
 |===
 
-| APP_NAME | Enter Application name. 
-
-| GIT_REPO | Enter Git Repository location. This is manadatory field. 
-
-| GIT_REF | Default value is master. This is git ref which is used to build application. 
-
-| SERVICE_NAME | Exposed service name 
-
-| BUILDER_VERSION | Builder version
-
-| APP_VERSION | Application version
-
-| MAVEN_ARGS | Default value is *`package -DskipTests -e`*. Enter arguments that are passed to mvn in the build.
-
-| MAVEN_ARGS_APPEND | Extra arguments passed to mvn, for example multi-module builds
-
-| ARTIFACT_DIR | Maven build directory
-
-| IMAGE_STREAM_NAMESPACE | Namespace in which the Fuse ImageStreams are installed.
-
-| BUILD_SECRET | generated if empty. The secret needed to trigger a build.
-
-|=== 
 
 For more information, see https://docs.openshift.com/enterprise/3.0/dev_guide/templates.html[*Application Templates*]
 
-=== Developing Applications 
+=== Developing Applications
 ==== Injecting Kubernetes services into applications
 
 You can inject Kubernetes services into applications by labeling the pods and use those labels to select the required pods to provide a logical service. These labels are simple key, value pairs.
@@ -210,7 +280,7 @@ Fabric8 provides a CDI extension that you can use to inject Kubernetes resources
 </dependency>
 ----
 
-Next step is to identify the field that requires the service and then inject the service by adding a *`@ServiceName*` annotation to it. For example, 
+Next step is to identify the field that requires the service and then inject the service by adding a *`@ServiceName*` annotation to it. For example,
 
 ----
 @Inject
@@ -218,9 +288,9 @@ Next step is to identify the field that requires the service and then inject the
 private String service.
 ----
 
-The *`@PortName*` annotation is used to select a specific port by name when multiple ports are defined for a service. 
+The *`@PortName*` annotation is used to select a specific port by name when multiple ports are defined for a service.
 
 
 ===== Using environment variables as properties
 
-You can use to access a service by using environment variables to expose the fixed IP address and port. These are, *`SERVICE_HOST*` and *`SERVICE_PORT*`. *`SERVICE_HOST*` is the host (IP) address of the service and *`SERVICE_PORT*` is the port of the service. 
+You can use to access a service by using environment variables to expose the fixed IP address and port. These are, *`SERVICE_HOST*` and *`SERVICE_PORT*`. *`SERVICE_HOST*` is the host (IP) address of the service and *`SERVICE_PORT*` is the port of the service.


### PR DESCRIPTION
Changes in detail:
- The Maven repositories which need to be configured
- How to provided credentials when pushing to the OpenShift registry
- Corrected (and verified) the mvn call for using the archetypes.
- Added to the profile description
- Extended the template parmeter list with some default values
- Removed trailing (invisible) spaces (sorry, that does my editor automatically).

I didn't verify the formatting, this could be broken. Feel free to ask me anything in case sth is unclear.
